### PR TITLE
Rename MesosSchedulerClient to MesosClient.

### DIFF
--- a/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/MesosClient.java
+++ b/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/MesosClient.java
@@ -51,11 +51,11 @@ import static rx.Observable.just;
  * <a target="_blank" href="https://github.com/apache/mesos/blob/master/docs/scheduler-http-api.md">HTTP Scheduler API</a>
  * @param <Send>       The type of Objects to be sent to Mesos
  * @param <Receive>    The type of Objects to expect from Mesos
- * @see MesosSchedulerClientBuilder
- * @see MesosSchedulerClientBuilders
+ * @see MesosClientBuilder
+ * @see MesosClientBuilders
  */
-public final class MesosSchedulerClient<Send, Receive> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MesosSchedulerClient.class);
+public final class MesosClient<Send, Receive> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MesosClient.class);
 
     @NotNull
     private final ExecutorService exec = Executors.newSingleThreadExecutor(r -> new Thread(r, "stream-monitor-thread"));
@@ -75,7 +75,7 @@ public final class MesosSchedulerClient<Send, Receive> {
     @VisibleForTesting
     final Func1<Send, Observable<HttpClientRequest<ByteBuf>>> createPost;
 
-    MesosSchedulerClient(
+    MesosClient(
         @NotNull final URI mesosUri,
         @NotNull final Function<Class<?>, UserAgentEntry> applicationUserAgentEntry,
         @NotNull final MessageCodec<Send> sendCodec,

--- a/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/MesosClientBuilder.java
+++ b/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/MesosClientBuilder.java
@@ -26,13 +26,13 @@ import java.util.function.Function;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Builder used to create a {@link MesosSchedulerClient}.
+ * Builder used to create a {@link MesosClient}.
  * <p>
  * PLEASE NOTE: All methods in this class function as "set" rather than "copy with new value"
  * @param <Send>       The type of objects that will be sent to Mesos
  * @param <Receive>    The type of objects are expected from Mesos
  */
-public final class MesosSchedulerClientBuilder<Send, Receive> {
+public final class MesosClientBuilder<Send, Receive> {
 
     private URI mesosUri;
     private Function<Class<?>, UserAgentEntry> applicationUserAgentEntry;
@@ -41,17 +41,17 @@ public final class MesosSchedulerClientBuilder<Send, Receive> {
     private Send subscribe;
     private Function<Observable<Receive>, Observable<Optional<SinkOperation<Send>>>> streamProcessor;
 
-    private MesosSchedulerClientBuilder() {}
+    private MesosClientBuilder() {}
 
     /**
-     * Create a new instance of MesosSchedulerClientBuilder
+     * Create a new instance of MesosClientBuilder
      * @param <Send>       The type of objects that will be sent to Mesos
      * @param <Receive>    The type of objects are expected from Mesos
-     * @return A new instance of MesosSchedulerClientBuilder
+     * @return A new instance of MesosClientBuilder
      */
     @NotNull
-    public static <Send, Receive> MesosSchedulerClientBuilder<Send, Receive> newBuilder() {
-        return new MesosSchedulerClientBuilder<>();
+    public static <Send, Receive> MesosClientBuilder<Send, Receive> newBuilder() {
+        return new MesosClientBuilder<>();
     }
 
     /**
@@ -67,7 +67,7 @@ public final class MesosSchedulerClientBuilder<Send, Receive> {
      * @return this builder (allowing for further chained calls)
      */
     @NotNull
-    public MesosSchedulerClientBuilder<Send, Receive> mesosUri(
+    public MesosClientBuilder<Send, Receive> mesosUri(
         @NotNull final URI mesosUri
     ) {
         this.mesosUri = mesosUri;
@@ -81,7 +81,7 @@ public final class MesosSchedulerClientBuilder<Send, Receive> {
      * @return this builder (allowing for further chained calls)
      */
     @NotNull
-    public MesosSchedulerClientBuilder<Send, Receive> applicationUserAgentEntry(
+    public MesosClientBuilder<Send, Receive> applicationUserAgentEntry(
         @NotNull final Function<Class<?>, UserAgentEntry> applicationUserAgentEntry
     ) {
         this.applicationUserAgentEntry = applicationUserAgentEntry;
@@ -94,7 +94,7 @@ public final class MesosSchedulerClientBuilder<Send, Receive> {
      * @return this builder (allowing for further chained calls)
      */
     @NotNull
-    public MesosSchedulerClientBuilder<Send, Receive> sendCodec(
+    public MesosClientBuilder<Send, Receive> sendCodec(
         @NotNull final MessageCodec<Send> sendCodec
     ) {
         this.sendCodec = sendCodec;
@@ -107,7 +107,7 @@ public final class MesosSchedulerClientBuilder<Send, Receive> {
      * @return this builder (allowing for further chained calls)
      */
     @NotNull
-    public MesosSchedulerClientBuilder<Send, Receive> receiveCodec(
+    public MesosClientBuilder<Send, Receive> receiveCodec(
         @NotNull final MessageCodec<Receive> receiveCodec
     ) {
         this.receiveCodec = receiveCodec;
@@ -121,7 +121,7 @@ public final class MesosSchedulerClientBuilder<Send, Receive> {
      * @return this builder (allowing for further chained calls)
      */
     @NotNull
-    public MesosSchedulerClientBuilder<Send, Receive> subscribe(
+    public MesosClientBuilder<Send, Receive> subscribe(
         @NotNull final Send subscribe
     ) {
         this.subscribe = subscribe;
@@ -153,7 +153,7 @@ public final class MesosSchedulerClientBuilder<Send, Receive> {
      * @return this builder (allowing for further chained calls)
      */
     @NotNull
-    public MesosSchedulerClientBuilder<Send, Receive> processStream(
+    public MesosClientBuilder<Send, Receive> processStream(
         @NotNull final Function<Observable<Receive>, Observable<Optional<SinkOperation<Send>>>> streamProcessing
     ) {
         this.streamProcessor = streamProcessing;
@@ -161,13 +161,13 @@ public final class MesosSchedulerClientBuilder<Send, Receive> {
     }
 
     /**
-     * Builds the instance of {@link MesosSchedulerClient} that has been configured by this builder.
+     * Builds the instance of {@link MesosClient} that has been configured by this builder.
      * All items are expected to have non-null values, if any item is null an exception will be thrown.
-     * @return The configured {@link MesosSchedulerClient}
+     * @return The configured {@link MesosClient}
      */
     @NotNull
-    public final MesosSchedulerClient<Send, Receive> build() {
-        return new MesosSchedulerClient<>(
+    public final MesosClient<Send, Receive> build() {
+        return new MesosClient<>(
             checkNotNull(mesosUri),
             checkNotNull(applicationUserAgentEntry),
             checkNotNull(sendCodec),

--- a/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/MesosClientBuilders.java
+++ b/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/MesosClientBuilders.java
@@ -20,17 +20,17 @@ import org.apache.mesos.v1.scheduler.Protos;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * A collection of methods that have some pre-defined {@link MesosSchedulerClientBuilder} configurations.
+ * A collection of methods that have some pre-defined {@link MesosClientBuilder} configurations.
  */
-public final class MesosSchedulerClientBuilders {
+public final class MesosClientBuilders {
     /**
-     * @return  An initial {@link MesosSchedulerClientBuilder} that will use protobuf
+     * @return  An initial {@link MesosClientBuilder} that will use protobuf
      *          for the {@link org.apache.mesos.v1.scheduler.Protos.Call} and
      *          {@link org.apache.mesos.v1.scheduler.Protos.Event} messages.
      */
     @NotNull
-    public static MesosSchedulerClientBuilder<Protos.Call, Protos.Event> usingProtos() {
-        return MesosSchedulerClientBuilder.<Protos.Call, Protos.Event>newBuilder()
+    public static MesosClientBuilder<Protos.Call, Protos.Event> schedulerUsingProtos() {
+        return MesosClientBuilder.<Protos.Call, Protos.Event>newBuilder()
             .sendCodec(MessageCodecs.PROTOS_CALL)
             .receiveCodec(MessageCodecs.PROTOS_EVENT)
             ;

--- a/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/package-info.java
+++ b/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/package-info.java
@@ -23,7 +23,7 @@
  * import static org.apache.mesos.v1.scheduler.Protos.*;
  *
  * final Protos.FrameworkID fwId = FrameworkID.newBuilder().setValue(UUID.randomUUID().toString()).build();
- * com.mesosphere.mesos.rx.java.MesosSchedulerClientBuilders.usingProtos()
+ * com.mesosphere.mesos.rx.java.MesosClientBuilders.schedulerUsingProtos()
  *     .mesosUri(URI.create("http://localhost:5050/api/v1/scheduler"))
  *     .applicationUserAgentEntry(UserAgentEntries.literal("decline-framework", "0.1.0-SNAPSHOT"))
  *     .subscribe(

--- a/mesos-rxjava-core/src/test/java/com/mesosphere/mesos/rx/java/MesosClientTest.java
+++ b/mesos-rxjava-core/src/test/java/com/mesosphere/mesos/rx/java/MesosClientTest.java
@@ -36,7 +36,7 @@ import static com.mesosphere.mesos.rx.java.UserAgentEntries.*;
 import static org.apache.mesos.v1.Protos.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public final class MesosSchedulerClientTest {
+public final class MesosClientTest {
 
     public static final Protos.Call ACK = ProtoUtils.ackUpdate(
         FrameworkID.newBuilder().setValue("fwId").build(),
@@ -48,7 +48,7 @@ public final class MesosSchedulerClientTest {
     @Test
     public void testUserAgentContains_MesosRxJavaCore_RxNetty() throws Exception {
         final String clientName = "unit-tests";
-        final MesosSchedulerClient<Protos.Call, Protos.Event> client = MesosSchedulerClientBuilders.usingProtos()
+        final MesosClient<Protos.Call, Protos.Event> client = MesosClientBuilders.schedulerUsingProtos()
             .mesosUri(URI.create("http://localhost:12345"))
             .applicationUserAgentEntry(literal(clientName, "latest"))
             .subscribe(TestingProtos.SUBSCRIBE)
@@ -85,7 +85,7 @@ public final class MesosSchedulerClientTest {
 
     @Test
     public void testRequestUriFromPassedUri() throws Exception {
-        final Func1<String, Observable<HttpClientRequest<ByteBuf>>> createPost = MesosSchedulerClient.curryCreatePost(
+        final Func1<String, Observable<HttpClientRequest<ByteBuf>>> createPost = MesosClient.curryCreatePost(
             URI.create("http://localhost:12345/glavin/api/v1/scheduler"),
             MessageCodecs.UTF8_STRING,
             MessageCodecs.UTF8_STRING,
@@ -103,7 +103,7 @@ public final class MesosSchedulerClientTest {
 
     @Test
     public void testBasicAuthHeaderAddedToRequestWhenUserInfoPresentInUri() throws Exception {
-        final Func1<String, Observable<HttpClientRequest<ByteBuf>>> createPost = MesosSchedulerClient.curryCreatePost(
+        final Func1<String, Observable<HttpClientRequest<ByteBuf>>> createPost = MesosClient.curryCreatePost(
             URI.create("http://testuser:testpassword@localhost:12345/api/v1/scheduler"),
             MessageCodecs.UTF8_STRING,
             MessageCodecs.UTF8_STRING,

--- a/mesos-rxjava-core/src/test/java/com/mesosphere/mesos/rx/java/SubscriberDecoratorTest.java
+++ b/mesos-rxjava-core/src/test/java/com/mesosphere/mesos/rx/java/SubscriberDecoratorTest.java
@@ -34,7 +34,7 @@ public final class SubscriberDecoratorTest {
     @Test
     public void worksForCompleted() throws Exception {
         final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
-        final MesosSchedulerClient.SubscriberDecorator<String> decorator = new MesosSchedulerClient.SubscriberDecorator<>(testSubscriber);
+        final MesosClient.SubscriberDecorator<String> decorator = new MesosClient.SubscriberDecorator<>(testSubscriber);
         Observable.just("something")
             .subscribe(decorator);
 
@@ -50,7 +50,7 @@ public final class SubscriberDecoratorTest {
     public void worksForError() throws Exception {
         final ExecutorService service = Executors.newSingleThreadExecutor();
         final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
-        final MesosSchedulerClient.SubscriberDecorator<String> decorator = new MesosSchedulerClient.SubscriberDecorator<>(testSubscriber);
+        final MesosClient.SubscriberDecorator<String> decorator = new MesosClient.SubscriberDecorator<>(testSubscriber);
         Observable.<String>from(service.submit(() -> {throw new RuntimeException("kaboom");}))
             .subscribe(decorator);
 
@@ -67,7 +67,7 @@ public final class SubscriberDecoratorTest {
 
     @Test
     public void exceptionThrowByOnErrorIsReturned() throws Exception {
-        final MesosSchedulerClient.SubscriberDecorator<String> decorator = new MesosSchedulerClient.SubscriberDecorator<>(
+        final MesosClient.SubscriberDecorator<String> decorator = new MesosClient.SubscriberDecorator<>(
             Subscribers.<String>create(
                 s -> {throw new RuntimeException("Supposed to break");},
                 (t) -> {throw new RuntimeException("wrapped", t);}
@@ -86,7 +86,7 @@ public final class SubscriberDecoratorTest {
 
     @Test
     public void exceptionThrowByOnCompletedIsReturned() throws Exception {
-        final MesosSchedulerClient.SubscriberDecorator<String> decorator = new MesosSchedulerClient.SubscriberDecorator<>(
+        final MesosClient.SubscriberDecorator<String> decorator = new MesosClient.SubscriberDecorator<>(
             Subscribers.<String>create(
                 s -> {},
                 (t) -> {throw new RuntimeException("wrapped", t);},
@@ -106,7 +106,7 @@ public final class SubscriberDecoratorTest {
     @Test(expected = StackOverflowError.class)
     public void fatalExceptionIsThrown() throws Exception {
         final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
-        final MesosSchedulerClient.SubscriberDecorator<String> decorator = new MesosSchedulerClient.SubscriberDecorator<>(testSubscriber);
+        final MesosClient.SubscriberDecorator<String> decorator = new MesosClient.SubscriberDecorator<>(testSubscriber);
         Observable.just("doesn't matter")
             .map((s) -> {
                 //noinspection ConstantIfStatement,ConstantConditions  -- This is here to trick the compiler to think this function returns a string
@@ -123,7 +123,7 @@ public final class SubscriberDecoratorTest {
     @Test
     public void onlyOneValueWillBeHeld_completed() throws Exception {
         final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
-        final MesosSchedulerClient.SubscriberDecorator<String> decorator = new MesosSchedulerClient.SubscriberDecorator<>(testSubscriber);
+        final MesosClient.SubscriberDecorator<String> decorator = new MesosClient.SubscriberDecorator<>(testSubscriber);
 
         decorator.onCompleted();
         decorator.onCompleted();
@@ -135,7 +135,7 @@ public final class SubscriberDecoratorTest {
     @Test
     public void receiveFirstValue_error() throws Exception {
         final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
-        final MesosSchedulerClient.SubscriberDecorator<String> decorator = new MesosSchedulerClient.SubscriberDecorator<>(testSubscriber);
+        final MesosClient.SubscriberDecorator<String> decorator = new MesosClient.SubscriberDecorator<>(testSubscriber);
 
         decorator.onError(new RuntimeException("this one"));
         decorator.onError(new RuntimeException("not this one"));
@@ -150,7 +150,7 @@ public final class SubscriberDecoratorTest {
     @Test
     public void onlyOneValueWillBeHeld_completedThenError() throws Exception {
         final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
-        final MesosSchedulerClient.SubscriberDecorator<String> decorator = new MesosSchedulerClient.SubscriberDecorator<>(testSubscriber);
+        final MesosClient.SubscriberDecorator<String> decorator = new MesosClient.SubscriberDecorator<>(testSubscriber);
 
         decorator.onCompleted();
         decorator.onError(new RuntimeException("really doesn't matter"));

--- a/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/java/com/mesosphere/mesos/rx/java/example/framework/sleepy/Sleepy.java
+++ b/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/java/com/mesosphere/mesos/rx/java/example/framework/sleepy/Sleepy.java
@@ -66,7 +66,7 @@ public final class Sleepy {
             final FrameworkID fwId = FrameworkID.newBuilder().setValue("sleepy-" + UUID.randomUUID()).build();
             final State<FrameworkID, TaskID, TaskState> state = new State<>(fwId, cpusPerTask, 32);
 
-            final MesosSchedulerClientBuilder<Call, Event> clientBuilder = MesosSchedulerClientBuilders.usingProtos()
+            final MesosClientBuilder<Call, Event> clientBuilder = MesosClientBuilders.schedulerUsingProtos()
                 .mesosUri(mesosUri)
                 .applicationUserAgentEntry(userAgentEntryForMavenArtifact("com.mesosphere.mesos.rx.java.example", "mesos-rxjava-example"));
 
@@ -79,7 +79,7 @@ public final class Sleepy {
 
     private static void _main(
         @NotNull final State<FrameworkID, TaskID, TaskState> stateObject,
-        @NotNull final MesosSchedulerClientBuilder<Call, Event> clientBuilder
+        @NotNull final MesosClientBuilder<Call, Event> clientBuilder
     ) throws Throwable {
 
         final Call subscribeCall = Call.newBuilder()


### PR DESCRIPTION
As of this point nothing in MesosClient is scheduler specific and could be used for an executor by creating a new builder and new codec.