### PR TITLE
Add MainClass to jar manifest.

### DIFF
--- a/mesos-rxjava-example/mesos-rxjava-example-framework/pom.xml
+++ b/mesos-rxjava-example/mesos-rxjava-example-framework/pom.xml
@@ -82,6 +82,11 @@
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.mesosphere.mesos.rx.java.example.framework.sleepy.Sleepy</mainClass>
+                        </manifest>
+                    </archive>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Update mesos-rxjava-example-framework jar so that the MainClass is set in the manifest to allow for `java -jar`