### PR TITLE
Update default port handling logic

### DIFF
--- a/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/MesosClient.java
+++ b/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/MesosClient.java
@@ -101,7 +101,7 @@ public final class MesosClient<Send, Receive> {
             userAgentEntryForGradleArtifact("rxnetty")
         );
 
-        httpClient = RxNetty.<ByteBuf, ByteBuf>newHttpClientBuilder(mesosUri.getHost(), mesosUri.getPort())
+        httpClient = RxNetty.<ByteBuf, ByteBuf>newHttpClientBuilder(mesosUri.getHost(), getPort(mesosUri))
             .withName(userAgent.getEntries().get(0).getName())
             .pipelineConfigurator(new HttpClientPipelineConfigurator<>())
             .build();
@@ -183,6 +183,23 @@ public final class MesosClient<Send, Receive> {
                 }
             }
         };
+    }
+
+    @VisibleForTesting
+    static int getPort(@NotNull final URI uri) {
+        final int uriPort = uri.getPort();
+        if (uriPort > 0) {
+            return uriPort;
+        } else {
+            switch (uri.getScheme()) {
+                case "http":
+                    return 80;
+                case "https":
+                    return 443;
+                default:
+                    throw new IllegalArgumentException("URI Scheme must be http or https");
+            }
+        }
     }
 
     /**

--- a/mesos-rxjava-client/src/test/java/com/mesosphere/mesos/rx/java/MesosClientTest.java
+++ b/mesos-rxjava-client/src/test/java/com/mesosphere/mesos/rx/java/MesosClientTest.java
@@ -199,6 +199,26 @@ public final class MesosClientTest {
         assertThat(mesosStreamId.get()).isEqualTo(null);
     }
 
+    @Test
+    public void testGetPort_returnsSpecifiedPort() throws Exception {
+        assertThat(MesosClient.getPort(URI.create("http://glavin:500/path"))).isEqualTo(500);
+    }
+
+    @Test
+    public void testGetPort_returns80ForHttp() throws Exception {
+        assertThat(MesosClient.getPort(URI.create("http://glavin/path"))).isEqualTo(80);
+    }
+
+    @Test
+    public void testGetPort_returns443ForHttps() throws Exception {
+        assertThat(MesosClient.getPort(URI.create("https://glavin/path"))).isEqualTo(443);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetPort_throwsExceptionWhenNoPortIsSpecifiedAndSchemeIsNotHttpOrHttps() throws Exception {
+        MesosClient.getPort(URI.create("ftp://glavin/path"));
+    }
+
     @NotNull
     private static Map<String, String> headersToMap(@NotNull final HttpRequestHeaders headers) {
         final HashMap<String, String> map = Maps.newHashMap();


### PR DESCRIPTION
Default port handling logic will now return the following ports for the specified scheme if no port is provided:
* http -> 80
* https -> 443