### PR TITLE
Update LegacySleepy and Sleepy to exit with usage message

### DIFF
--- a/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/java/com/mesosphere/mesos/rx/java/example/framework/sleepy/LegacySleepy.java
+++ b/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/java/com/mesosphere/mesos/rx/java/example/framework/sleepy/LegacySleepy.java
@@ -53,14 +53,15 @@ public final class LegacySleepy implements Scheduler {
     public static void main(String[] args) {
         try {
             if (args.length != 2) {
-                final String className = Sleepy.class.getCanonicalName();
+                final String className = LegacySleepy.class.getCanonicalName();
                 System.err.println("Usage: java -cp <application-jar> " + className + " <mesos-zk-uri> <cpus-per-task>");
+                System.exit(1);
             }
 
             final String mesosUri = args[0];
             final double cpusPerTask = Double.parseDouble(args[1]);
             final FrameworkID fwId = FrameworkID.newBuilder().setValue("legacy-sleepy-" + UUID.randomUUID()).build();
-            final State<FrameworkID, TaskID, TaskState> state = new State<>(fwId, cpusPerTask, 32);
+            final State<FrameworkID, TaskID, TaskState> state = new State<>(fwId, cpusPerTask, 16);
 
             final Scheduler scheduler = new LegacySleepy(state);
             final FrameworkInfo frameworkInfo = FrameworkInfo.newBuilder()

--- a/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/java/com/mesosphere/mesos/rx/java/example/framework/sleepy/Sleepy.java
+++ b/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/java/com/mesosphere/mesos/rx/java/example/framework/sleepy/Sleepy.java
@@ -74,12 +74,13 @@ public final class Sleepy {
         if (args.length != 2) {
             final String className = Sleepy.class.getCanonicalName();
             System.err.println("Usage: java -cp <application-jar> " + className + " <mesos-uri> <cpus-per-task>");
+            System.exit(1);
         }
 
         final URI mesosUri = URI.create(args[0]);
         final double cpusPerTask = Double.parseDouble(args[1]);
         final FrameworkID frameworkID = FrameworkID.newBuilder().setValue(fwId).build();
-        final State<FrameworkID, TaskID, TaskState> stateObject = new State<>(frameworkID, cpusPerTask, 32);
+        final State<FrameworkID, TaskID, TaskState> stateObject = new State<>(frameworkID, cpusPerTask, 16);
 
         final MesosClientBuilder<Call, Event> clientBuilder = ProtobufMesosClientBuilder.schedulerUsingProtos()
             .mesosUri(mesosUri)


### PR DESCRIPTION
Update LegacySleepy and Sleepy to exit with usage message when an incorrect number of arguments are provided.