### PR TITLE
Rename MesosSchedulerSimulation to MesosServerSimulation

### DIFF
--- a/mesos-rxjava-example/mesos-rxjava-example-framework/src/test/java/com/mesosphere/mesos/rx/java/example/framework/sleepy/SleepySimulationTest.java
+++ b/mesos-rxjava-example/mesos-rxjava-example-framework/src/test/java/com/mesosphere/mesos/rx/java/example/framework/sleepy/SleepySimulationTest.java
@@ -20,7 +20,7 @@ import com.google.protobuf.ByteString;
 import com.mesosphere.mesos.rx.java.protobuf.ProtobufMessageCodecs;
 import com.mesosphere.mesos.rx.java.protobuf.SchedulerCalls;
 import com.mesosphere.mesos.rx.java.test.Async;
-import com.mesosphere.mesos.rx.java.test.simulation.MesosSchedulerSimulation;
+import com.mesosphere.mesos.rx.java.test.simulation.MesosServerSimulation;
 import org.apache.mesos.v1.scheduler.Protos;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
@@ -57,14 +57,14 @@ public final class SleepySimulationTest {
     public Async async = new Async();
 
     private BehaviorSubject<Protos.Event> subject;
-    private MesosSchedulerSimulation<Protos.Event, Protos.Call> sim;
+    private MesosServerSimulation<Protos.Event, Protos.Call> sim;
 
     private URI uri;
 
     @Before
     public void setUp() throws Exception {
         subject = BehaviorSubject.create();
-        sim = new MesosSchedulerSimulation<>(
+        sim = new MesosServerSimulation<>(
             subject,
             ProtobufMessageCodecs.SCHEDULER_EVENT,
             ProtobufMessageCodecs.SCHEDULER_CALL,

--- a/mesos-rxjava-example/mesos-rxjava-example-framework/src/test/resources/logback-test.xml
+++ b/mesos-rxjava-example/mesos-rxjava-example-framework/src/test/resources/logback-test.xml
@@ -27,7 +27,7 @@
 
     <!--<logger name="com.mesosphere.mesos.rx.java" level="debug"/>-->
     <!--<logger name="com.mesosphere.mesos.rx.java.example.framework.sleepy" level="debug"/>-->
-    <!--<logger name="com.mesosphere.mesos.rx.java.test.simulation.MesosSchedulerSimulation" level="trace"/>-->
+    <!--<logger name="com.mesosphere.mesos.rx.java.test.simulation.MesosServerSimulationevel="trace"/>-->
     <logger name="io.netty.handler.logging.LoggingHandler" level="info"/>
 
     <root level="info">

--- a/mesos-rxjava-test/src/main/java/com/mesosphere/mesos/rx/java/test/simulation/MesosServerSimulation.java
+++ b/mesos-rxjava-test/src/main/java/com/mesosphere/mesos/rx/java/test/simulation/MesosServerSimulation.java
@@ -46,7 +46,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
 /**
- * {@code MesosSchedulerSimulation} provides a server implementing the same protocol defined by Apache Mesos for its
+ * {@code MesosServerSimulation} provides a server implementing the same protocol defined by Apache Mesos for its
  * <a href="https://github.com/apache/mesos/blob/master/docs/scheduler-http-api.md">HTTP Scheduler API</a>.
  * The server has the following behavior:
  * <ol>
@@ -61,8 +61,8 @@ import java.util.function.Predicate;
  * <li>Server only supports one event stream, once that stream is complete a new server will need to be created.</li>
  * </ol>
  */
-public final class MesosSchedulerSimulation<Event, Call> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MesosSchedulerSimulation.class);
+public final class MesosServerSimulation<Event, Call> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MesosServerSimulation.class);
     private static final Marker RECEIVE_MARKER = MarkerFactory.getMarker("<<<");
     private static final Marker SEND_MARKER = MarkerFactory.getMarker(">>>");
 
@@ -85,7 +85,7 @@ public final class MesosSchedulerSimulation<Event, Call> {
     private Semaphore sem;
 
     /**
-     * Create a {@code MesosSchedulerSimulation} that will use {@code events} as the event stream to return to a
+     * Create a {@code MesosServerSimulation} that will use {@code events} as the event stream to return to a
      * a client when {@code isSubscribePredicate} evaluates to {@code true}
      * <p>
      * The simulation server must be started using {@link #start()} before requests can be serviced by the server.
@@ -97,7 +97,7 @@ public final class MesosSchedulerSimulation<Event, Call> {
      * @param receiveCodec         The {@link MessageCodec} to use to decode {@link Call}s received by the server
      * @param isSubscribePredicate The predicate used to determine if a {@link Call} is a "Subscribe" call
      */
-    public MesosSchedulerSimulation(
+    public MesosServerSimulation(
         @NotNull final Observable<Event> events,
         @NotNull final MessageCodec<Event> sendCodec,
         @NotNull final MessageCodec<Call> receiveCodec,

--- a/mesos-rxjava-test/src/test/java/com/mesosphere/mesos/rx/java/test/simulation/MesosServerSimulationScenariosTest.java
+++ b/mesos-rxjava-test/src/test/java/com/mesosphere/mesos/rx/java/test/simulation/MesosServerSimulationScenariosTest.java
@@ -43,7 +43,7 @@ import static com.mesosphere.mesos.rx.java.util.CollectionUtils.deepEquals;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public final class MesosSchedulerSimulationScenariosTest {
+public final class MesosServerSimulationScenariosTest {
 
     public static final String SUBSCRIBE = "subscribe";
     public static final String SUBSCRIBED = "subscribed";
@@ -68,7 +68,7 @@ public final class MesosSchedulerSimulationScenariosTest {
             .map(RecordIOUtils::createChunk)
             .collect(Collectors.toList());
 
-        final MesosSchedulerSimulation<String, String> sim = new MesosSchedulerSimulation<>(
+        final MesosServerSimulation<String, String> sim = new MesosServerSimulation<>(
             Observable.from(events),
             StringMessageCodec.UTF8_STRING,
             StringMessageCodec.UTF8_STRING,
@@ -84,7 +84,7 @@ public final class MesosSchedulerSimulationScenariosTest {
                 assertThat(response.getStatus()).isEqualTo(HttpResponseStatus.OK);
                 return response.getContent();
             })
-            .map(MesosSchedulerSimulationScenariosTest::bufToBytes)
+            .map(MesosServerSimulationScenariosTest::bufToBytes)
             ;
 
         final TestSubscriber<byte[]> testSubscriber = new TestSubscriber<>();
@@ -134,7 +134,7 @@ public final class MesosSchedulerSimulationScenariosTest {
          * events to it's subscriber without any buffering.
          */
         final BehaviorSubject<String> subject = BehaviorSubject.create();
-        final MesosSchedulerSimulation<String, String> sim = new MesosSchedulerSimulation<>(
+        final MesosServerSimulation<String, String> sim = new MesosServerSimulation<>(
             Observable.from(events),
             StringMessageCodec.UTF8_STRING,
             StringMessageCodec.UTF8_STRING,
@@ -184,7 +184,7 @@ public final class MesosSchedulerSimulationScenariosTest {
             .map(RecordIOUtils::createChunk)
             .collect(Collectors.toList());
 
-        final MesosSchedulerSimulation<String, String> sim = new MesosSchedulerSimulation<>(
+        final MesosServerSimulation<String, String> sim = new MesosServerSimulation<>(
             Observable.from(events),
             StringMessageCodec.UTF8_STRING,
             StringMessageCodec.UTF8_STRING,
@@ -216,7 +216,7 @@ public final class MesosSchedulerSimulationScenariosTest {
 
     @Test
     public void onlyOneSubscriptionPerServer() throws Exception {
-        final MesosSchedulerSimulation<String, String> sim = new MesosSchedulerSimulation<>(
+        final MesosServerSimulation<String, String> sim = new MesosServerSimulation<>(
             Observable.just(SUBSCRIBED),
             StringMessageCodec.UTF8_STRING,
             StringMessageCodec.UTF8_STRING,
@@ -232,7 +232,7 @@ public final class MesosSchedulerSimulationScenariosTest {
                 assertThat(response.getStatus()).isEqualTo(HttpResponseStatus.OK);
                 return response.getContent();
             })
-            .map(MesosSchedulerSimulationScenariosTest::bufToBytes)
+            .map(MesosServerSimulationScenariosTest::bufToBytes)
             ;
 
         final TestSubscriber<byte[]> testSubscriber = new TestSubscriber<>();
@@ -294,7 +294,7 @@ public final class MesosSchedulerSimulationScenariosTest {
                 return message;
             }
         };
-        final MesosSchedulerSimulation<String, String> sim = new MesosSchedulerSimulation<>(
+        final MesosServerSimulation<String, String> sim = new MesosServerSimulation<>(
             Observable.just(SUBSCRIBED),
             StringMessageCodec.UTF8_STRING,
             receiveCodec,
@@ -336,7 +336,7 @@ public final class MesosSchedulerSimulationScenariosTest {
 
                 return response.getContent();
             })
-            .map(MesosSchedulerSimulationScenariosTest::bufToBytes)
+            .map(MesosServerSimulationScenariosTest::bufToBytes)
             .onBackpressureBuffer();
     }
 

--- a/mesos-rxjava-test/src/test/java/com/mesosphere/mesos/rx/java/test/simulation/MesosServerSimulationTest.java
+++ b/mesos-rxjava-test/src/test/java/com/mesosphere/mesos/rx/java/test/simulation/MesosServerSimulationTest.java
@@ -32,9 +32,9 @@ import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public final class MesosSchedulerSimulationTest {
+public final class MesosServerSimulationTest {
 
-    private final MesosSchedulerSimulation<String, String> mesosSchedulerSimulation = new MesosSchedulerSimulation<>(
+    private final MesosServerSimulation<String, String> mesosServerSimulation = new MesosServerSimulation<>(
         BehaviorSubject.create(),
         StringMessageCodec.UTF8_STRING,
         StringMessageCodec.UTF8_STRING,
@@ -44,12 +44,12 @@ public final class MesosSchedulerSimulationTest {
 
     @Before
     public void setUp() throws Exception {
-        serverPort = mesosSchedulerSimulation.start();
+        serverPort = mesosServerSimulation.start();
     }
 
     @After
     public void tearDown() throws Exception {
-        mesosSchedulerSimulation.shutdown();
+        mesosServerSimulation.shutdown();
     }
 
     @Test
@@ -61,8 +61,8 @@ public final class MesosSchedulerSimulationTest {
         final HttpResponseHeaders headers = response.getHeaders();
         assertThat(headers.getHeader("Accept")).isEqualTo(StringMessageCodec.UTF8_STRING.mediaType());
 
-        assertThat(mesosSchedulerSimulation.getCallsReceived()).hasSize(1);
-        assertThat(mesosSchedulerSimulation.getCallsReceived()).contains("decline");
+        assertThat(mesosServerSimulation.getCallsReceived()).hasSize(1);
+        assertThat(mesosServerSimulation.getCallsReceived()).contains("decline");
     }
 
     @Test
@@ -74,7 +74,7 @@ public final class MesosSchedulerSimulationTest {
         final HttpResponseHeaders headers = response.getHeaders();
         assertThat(headers.getHeader("Accept")).isEqualTo(StringMessageCodec.UTF8_STRING.mediaType());
 
-        assertThat(mesosSchedulerSimulation.getCallsReceived()).hasSize(0);
+        assertThat(mesosServerSimulation.getCallsReceived()).hasSize(0);
     }
 
     @Test
@@ -95,7 +95,7 @@ public final class MesosSchedulerSimulationTest {
         final HttpResponseHeaders headers = response.getHeaders();
         assertThat(headers.getHeader("Accept")).isEqualTo(StringMessageCodec.UTF8_STRING.mediaType());
 
-        assertThat(mesosSchedulerSimulation.getCallsReceived()).hasSize(0);
+        assertThat(mesosServerSimulation.getCallsReceived()).hasSize(0);
     }
 
     @Test
@@ -119,7 +119,7 @@ public final class MesosSchedulerSimulationTest {
         final HttpResponseHeaders headers = response.getHeaders();
         assertThat(headers.getHeader("Accept")).isEqualTo(StringMessageCodec.UTF8_STRING.mediaType());
 
-        assertThat(mesosSchedulerSimulation.getCallsReceived()).hasSize(0);
+        assertThat(mesosServerSimulation.getCallsReceived()).hasSize(0);
     }
 
     @Test
@@ -142,7 +142,7 @@ public final class MesosSchedulerSimulationTest {
         final HttpResponseHeaders headers = response.getHeaders();
         assertThat(headers.getHeader("Accept")).isEqualTo(StringMessageCodec.UTF8_STRING.mediaType());
 
-        assertThat(mesosSchedulerSimulation.getCallsReceived()).hasSize(0);
+        assertThat(mesosServerSimulation.getCallsReceived()).hasSize(0);
     }
 
     @NotNull


### PR DESCRIPTION
MesosSchedulerSimulation is no longer Scheduler specific and can also be used for simulating an agent to an executor as well.