### PR TITLE
Add Mesos Executor support

### DIFF
--- a/mesos-rxjava-protobuf-client/src/main/java/com/mesosphere/mesos/rx/java/protobuf/ProtobufMesosClientBuilder.java
+++ b/mesos-rxjava-protobuf-client/src/main/java/com/mesosphere/mesos/rx/java/protobuf/ProtobufMesosClientBuilder.java
@@ -38,4 +38,20 @@ public final class ProtobufMesosClientBuilder {
             .receiveCodec(ProtobufMessageCodecs.SCHEDULER_EVENT)
             ;
     }
+
+    /**
+     * @return  An initial {@link MesosClientBuilder} that will use protobuf
+     *          for the {@link org.apache.mesos.v1.executor.Protos.Call Call} and
+     *          {@link org.apache.mesos.v1.executor.Protos.Event Event} messages.
+     */
+    @NotNull
+    public static MesosClientBuilder<
+        org.apache.mesos.v1.executor.Protos.Call,
+        org.apache.mesos.v1.executor.Protos.Event
+        > executorUsingProtos() {
+        return MesosClientBuilder.<org.apache.mesos.v1.executor.Protos.Call, org.apache.mesos.v1.executor.Protos.Event>newBuilder()
+            .sendCodec(ProtobufMessageCodecs.EXECUTOR_CALL)
+            .receiveCodec(ProtobufMessageCodecs.EXECUTOR_EVENT)
+            ;
+    }
 }

--- a/mesos-rxjava-protobuf-client/src/main/java/com/mesosphere/mesos/rx/java/protobuf/ProtobufMessageCodecs.java
+++ b/mesos-rxjava-protobuf-client/src/main/java/com/mesosphere/mesos/rx/java/protobuf/ProtobufMessageCodecs.java
@@ -37,4 +37,14 @@ public final class ProtobufMessageCodecs {
         Protos.Event::parseFrom, Protos.Event::parseFrom
     );
 
+    /** A {@link MessageCodec} for {@link org.apache.mesos.v1.executor.Protos.Call Call}. */
+    public static final MessageCodec<org.apache.mesos.v1.executor.Protos.Call> EXECUTOR_CALL = new ProtoCodec<>(
+        org.apache.mesos.v1.executor.Protos.Call::parseFrom, org.apache.mesos.v1.executor.Protos.Call::parseFrom
+    );
+
+    /** A {@link MessageCodec} for {@link org.apache.mesos.v1.executor.Protos.Event Event}. */
+    public static final MessageCodec<org.apache.mesos.v1.executor.Protos.Event> EXECUTOR_EVENT = new ProtoCodec<>(
+        org.apache.mesos.v1.executor.Protos.Event::parseFrom, org.apache.mesos.v1.executor.Protos.Event::parseFrom
+    );
+
 }

--- a/mesos-rxjava-protobuf-client/src/test/java/com/mesosphere/mesos/rx/java/protobuf/ProtobufMessageCodecsTest.java
+++ b/mesos-rxjava-protobuf-client/src/test/java/com/mesosphere/mesos/rx/java/protobuf/ProtobufMessageCodecsTest.java
@@ -16,7 +16,6 @@
 
 package com.mesosphere.mesos.rx.java.protobuf;
 
-import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.mesos.v1.scheduler.Protos;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
@@ -24,7 +23,6 @@ import org.junit.Test;
 import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public final class ProtobufMessageCodecsTest {
 
@@ -64,19 +62,6 @@ public final class ProtobufMessageCodecsTest {
         assertThat(HEARTBEAT).isEqualTo(ProtobufMessageCodecs.SCHEDULER_EVENT.decode(SERIALIZED_HEARTBEAT));
         assertThat(OFFER).isEqualTo(ProtobufMessageCodecs.SCHEDULER_EVENT.decode(SERIALIZED_OFFER));
         assertThat(SUBSCRIBED).isEqualTo(ProtobufMessageCodecs.SCHEDULER_EVENT.decode(SERIALIZED_SUBSCRIBED));
-    }
-
-    @Test
-    public void testDecodeFailure() {
-        assertDecodeFailure(SERIALIZED_HEARTBEAT);
-        assertDecodeFailure(SERIALIZED_OFFER);
-        assertDecodeFailure(SERIALIZED_SUBSCRIBED);
-    }
-
-    private static void assertDecodeFailure(@NotNull final byte[] protoBytes) {
-        assertThatExceptionOfType(RuntimeException.class)
-            .isThrownBy(() -> ProtobufMessageCodecs.SCHEDULER_CALL.decode(protoBytes))
-            .withCauseExactlyInstanceOf(InvalidProtocolBufferException.class);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,9 @@
 
         <version.rxJava>1.0.14</version.rxJava>
         <version.rxNetty>0.4.11</version.rxNetty>
-        <version.protobuf>2.5.0</version.protobuf>
+        <version.protobuf>2.6.1</version.protobuf>
         <version.netty>4.0.25.Final</version.netty>
-        <version.mesos>0.25.0</version.mesos>
+        <version.mesos>1.0.0-rc1</version.mesos>
 
         <!-- By default we skip deploy of all modules. Any module that should be deployed is explicitly enabled -->
         <module.deploy.skip>true</module.deploy.skip>


### PR DESCRIPTION
Update Mesos dependency to use 1.0.0-rc1 which requires protobuf 2.6.1.

The decode test in ProtobufMessageCodecsTest have been removed in this update because the new mesos protos have all properties marked as optional (no longer some of them are required).  Since all properties are optional it is now possible to "successfully" parse the bytes of a different message type into the desired message (the bytes of a heartbeat can be successfully parsed as a Subscribe call).