### PR TITLE
Update project to move Guava dependency to test scope

### DIFF
--- a/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/MesosClient.java
+++ b/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/MesosClient.java
@@ -16,7 +16,6 @@
 
 package com.mesosphere.mesos.rx.java;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.mesosphere.mesos.rx.java.recordio.RecordIOOperator;
 import com.mesosphere.mesos.rx.java.util.MessageCodec;
 import com.mesosphere.mesos.rx.java.util.UserAgent;
@@ -75,7 +74,7 @@ public final class MesosClient<Send, Receive> {
     private final Function<Observable<Receive>, Observable<Optional<SinkOperation<Send>>>> streamProcessor;
 
     @NotNull
-    @VisibleForTesting
+    // @VisibleForTesting
     final Func1<Send, Observable<HttpClientRequest<ByteBuf>>> createPost;
     @NotNull
     private final UserAgent userAgent;
@@ -181,7 +180,7 @@ public final class MesosClient<Send, Receive> {
     }
 
     @NotNull
-    @VisibleForTesting
+    // @VisibleForTesting
     static URI getUriFromRedirectResponse(final @NotNull URI mesosUri, @NotNull final HttpClientResponse<ByteBuf> redirectResponse) {
         if (redirectResponse.getStatus().equals(HttpResponseStatus.TEMPORARY_REDIRECT)) {
             final String location = redirectResponse.getHeaders().get("Location");
@@ -195,7 +194,7 @@ public final class MesosClient<Send, Receive> {
     }
 
     @NotNull
-    @VisibleForTesting
+    // @VisibleForTesting
     static URI resolveRelativeUri(final @NotNull URI mesosUri, final String location) {
         final URI relativeUri = mesosUri.resolve(location);
         try {
@@ -214,13 +213,13 @@ public final class MesosClient<Send, Receive> {
     }
 
     @NotNull
-    @VisibleForTesting
+    // @VisibleForTesting
     static String createRedirectUri(@NotNull final URI uri) {
         return uri.toString().replaceAll("/api/v1/(?:scheduler|executor)", "/redirect");
     }
 
     @NotNull
-    @VisibleForTesting
+    // @VisibleForTesting
     static <Send> Func1<HttpClientResponse<ByteBuf>, Observable<ByteBuf>> verifyResponseOk(
         @NotNull final Send subscription,
         @NotNull final AtomicReference<String> mesosStreamId,
@@ -272,7 +271,7 @@ public final class MesosClient<Send, Receive> {
         };
     }
 
-    @VisibleForTesting
+    // @VisibleForTesting
     static int getPort(@NotNull final URI uri) {
         final int uriPort = uri.getPort();
         if (uriPort > 0) {
@@ -331,7 +330,7 @@ public final class MesosClient<Send, Receive> {
      * item onto a blocking queue. {@link Callable#call()} will then block until there is an item on the queue.
      * If the item in the queue contains an exception, that exception will be throw back up to the user.
      */
-    @VisibleForTesting
+    // @VisibleForTesting
     static final class SubscriberDecorator<T> extends Subscriber<T> implements Callable<Optional<Throwable>> {
         @NotNull
         private final Subscriber<T> delegate;
@@ -388,7 +387,7 @@ public final class MesosClient<Send, Receive> {
     }
 
     @NotNull
-    @VisibleForTesting
+    // @VisibleForTesting
     static <Send, Receive> Func1<Send, Observable<HttpClientRequest<ByteBuf>>> curryCreatePost(
         @NotNull final URI mesosUri,
         @NotNull final MessageCodec<Send> sendCodec,

--- a/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/MesosClientBuilder.java
+++ b/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/MesosClientBuilder.java
@@ -25,7 +25,7 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.function.Function;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.mesosphere.mesos.rx.java.util.Validations.checkNotNull;
 
 /**
  * Builder used to create a {@link MesosClient}.

--- a/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/MesosClientErrorContext.java
+++ b/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/MesosClientErrorContext.java
@@ -16,7 +16,6 @@
 
 package com.mesosphere.mesos.rx.java;
 
-import com.google.common.base.Joiner;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -29,7 +28,6 @@ import java.util.Objects;
  * present in the response.
  */
 public final class MesosClientErrorContext {
-    private static final Joiner MAP_JOINER = Joiner.on(",").skipNulls();
 
     private final int statusCode;
     private final String message;
@@ -90,7 +88,6 @@ public final class MesosClientErrorContext {
         return "MesosClientErrorContext{" +
             "statusCode=" + statusCode +
             ", message='" + message + '\'' +
-            ", headers=" + MAP_JOINER.join(headers) +
             '}';
     }
 

--- a/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/SinkOperation.java
+++ b/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/SinkOperation.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import rx.functions.Action0;
 import rx.functions.Action1;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.mesosphere.mesos.rx.java.util.Validations.checkNotNull;
 
 /**
  * A simple object that represents a {@link T} that is to be sent to Mesos.

--- a/mesos-rxjava-example/mesos-rxjava-example-framework/pom.xml
+++ b/mesos-rxjava-example/mesos-rxjava-example-framework/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>mesos-rxjava-test</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.mesos</groupId>
             <artifactId>mesos</artifactId>
         </dependency>

--- a/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/java/com/mesosphere/mesos/rx/java/example/framework/sleepy/State.java
+++ b/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/java/com/mesosphere/mesos/rx/java/example/framework/sleepy/State.java
@@ -21,9 +21,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.google.common.collect.Maps.newConcurrentMap;
 import static com.mesosphere.mesos.rx.java.protobuf.ProtoUtils.protoToString;
 
 final class State<FwId, TaskId, TaskState> {
@@ -54,7 +54,7 @@ final class State<FwId, TaskId, TaskState> {
         this.resourceRole = resourceRole;
         this.cpusPerTask = cpusPerTask;
         this.memMbPerTask = memMbPerTask;
-        this.taskStates = newConcurrentMap();
+        this.taskStates = new ConcurrentHashMap<>();
     }
 
     @NotNull

--- a/mesos-rxjava-protobuf-client/src/main/java/com/mesosphere/mesos/rx/java/protobuf/SchedulerEvents.java
+++ b/mesos-rxjava-protobuf-client/src/main/java/com/mesosphere/mesos/rx/java/protobuf/SchedulerEvents.java
@@ -16,11 +16,12 @@
 
 package com.mesosphere.mesos.rx.java.protobuf;
 
-import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
 import org.apache.mesos.v1.scheduler.Protos;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
 
 /**
  * A set of factory methods that make {@link Protos.Event Event}s easier to create.
@@ -84,7 +85,7 @@ public final class SchedulerEvents {
             .setType(Protos.Event.Type.OFFERS)
             .setOffers(
                 Protos.Event.Offers.newBuilder()
-                    .addAllOffers(Lists.newArrayList(
+                    .addAllOffers(Collections.singletonList(
                         org.apache.mesos.v1.Protos.Offer.newBuilder()
                             .setHostname(hostname)
                             .setId(org.apache.mesos.v1.Protos.OfferID.newBuilder().setValue(offerId))

--- a/mesos-rxjava-test/src/main/java/com/mesosphere/mesos/rx/java/test/Async.java
+++ b/mesos-rxjava-test/src/main/java/com/mesosphere/mesos/rx/java/test/Async.java
@@ -20,12 +20,11 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 import org.jetbrains.annotations.NotNull;
 import org.junit.rules.Verifier;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static com.google.common.collect.Lists.newArrayList;
 
 /**
  * A JUnit {@link org.junit.rules.TestRule Rule} that provides a convenience method to run async tasks.
@@ -65,7 +64,7 @@ public final class Async extends Verifier {
     public Async() {
         counter = new AtomicInteger(0);
         executor = Executors.newCachedThreadPool(new DefaultThreadFactory(Async.class));
-        tasks = Collections.synchronizedList(newArrayList());
+        tasks = Collections.synchronizedList(new ArrayList<>());
     }
 
     /**

--- a/mesos-rxjava-test/src/main/java/com/mesosphere/mesos/rx/java/test/RecordIOUtils.java
+++ b/mesos-rxjava-test/src/main/java/com/mesosphere/mesos/rx/java/test/RecordIOUtils.java
@@ -16,17 +16,18 @@
 
 package com.mesosphere.mesos.rx.java.test;
 
-import com.google.common.base.Charsets;
 import org.jetbrains.annotations.NotNull;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.nio.charset.StandardCharsets;
+
+import static com.mesosphere.mesos.rx.java.util.Validations.checkNotNull;
 
 /**
  * A set of utilities for dealing with the RecordIO format.
  * @see <a href="https://github.com/apache/mesos/blob/master/docs/scheduler-http-api.md#recordio-response-format" target="_blank">RecordIO</a>
  */
 public final class RecordIOUtils {
-    private static final byte NEW_LINE_BYTE = Charsets.UTF_8.encode("\n").array()[0];
+    private static final byte NEW_LINE_BYTE = "\n".getBytes(StandardCharsets.UTF_8)[0];
     private static final int NEW_LINE_BYTE_SIZE = 1;
 
     private RecordIOUtils() {}
@@ -34,7 +35,7 @@ public final class RecordIOUtils {
     @NotNull
     public static byte[] createChunk(@NotNull final byte[] bytes) {
         checkNotNull(bytes, "bytes must not be null");
-        final byte[] messageSize = Charsets.UTF_8.encode(Integer.toString(bytes.length)).array();
+        final byte[] messageSize = Integer.toString(bytes.length).getBytes(StandardCharsets.UTF_8);
 
         final int messageSizeLength = messageSize.length;
         final int chunkSize = messageSizeLength + NEW_LINE_BYTE_SIZE + bytes.length;

--- a/mesos-rxjava-test/src/main/java/com/mesosphere/mesos/rx/java/test/StringMessageCodec.java
+++ b/mesos-rxjava-test/src/main/java/com/mesosphere/mesos/rx/java/test/StringMessageCodec.java
@@ -16,13 +16,14 @@
 
 package com.mesosphere.mesos.rx.java.test;
 
-import com.google.common.io.CharStreams;
 import com.mesosphere.mesos.rx.java.util.MessageCodec;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -52,7 +53,15 @@ public final class StringMessageCodec implements MessageCodec<String> {
     @Override
     public String decode(@NotNull final InputStream in) {
         try {
-            return CharStreams.toString(new InputStreamReader(in, StandardCharsets.UTF_8));
+            final StringBuilder sb = new StringBuilder();
+            final Reader reader = new InputStreamReader(in, StandardCharsets.UTF_8);
+            final CharBuffer buffer = CharBuffer.allocate(0x800);// 2k chars (4k bytes)
+            while (reader.read(buffer) != -1) {
+                buffer.flip();
+                sb.append(buffer);
+                buffer.clear();
+            }
+            return sb.toString();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/mesos-rxjava-util/src/main/java/com/mesosphere/mesos/rx/java/util/UserAgent.java
+++ b/mesos-rxjava-util/src/main/java/com/mesosphere/mesos/rx/java/util/UserAgent.java
@@ -16,7 +16,6 @@
 
 package com.mesosphere.mesos.rx.java.util;
 
-import com.google.common.base.Joiner;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -29,8 +28,6 @@ import java.util.stream.Collectors;
  * This class represents an HTTP User-Agent Header
  */
 public final class UserAgent {
-
-    private static final Joiner JOINER = Joiner.on(" ").skipNulls();
 
     @NotNull
     private final List<UserAgentEntry> entries;
@@ -46,7 +43,10 @@ public final class UserAgent {
                     .map(f -> f.apply(this.getClass()))
                     .collect(Collectors.toList())
             );
-        this.toStringValue = JOINER.join(this.entries);
+        this.toStringValue = this.entries
+            .stream()
+            .map(UserAgentEntry::toString)
+            .collect(Collectors.joining(" "));
     }
 
     @NotNull

--- a/mesos-rxjava-util/src/main/java/com/mesosphere/mesos/rx/java/util/Validations.java
+++ b/mesos-rxjava-util/src/main/java/com/mesosphere/mesos/rx/java/util/Validations.java
@@ -1,0 +1,56 @@
+/*
+ *    Copyright (C) 2016 Mesosphere, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mesosphere.mesos.rx.java.util;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A collection of utility methods replicating functionality provided by the {@code Preconditions} class in Guava.
+ * These methods are replicated here so that our projects production libraries don't have a dependency on Guava.
+ */
+public class Validations {
+
+    /**
+     * Check that {@code ref} is non-null, throw a {@link NullPointerException} otherwise
+
+     * @param ref    The reference to check for nullity, and be returned if non-null
+     * @param <T>    The type of ref
+     * @return       {@code ref} if non-null
+     * @throws NullPointerException if {@code ref} is null
+     */
+    public static <T> T checkNotNull(@Nullable T ref) {
+        return checkNotNull(ref, null);
+    }
+
+    /**
+     * Check that {@code ref} is non-null, throw a {@link NullPointerException} otherwise
+     *
+     * @param ref          The reference to check for nullity, and be returned if non-null
+     * @param errorMessage The error message to set on the {@link NullPointerException}
+     * @param <T>          The type of ref
+     * @return {@code ref} if non-null
+     * @throws NullPointerException if {@code ref} is null
+     */
+    public static <T> T checkNotNull(@Nullable T ref, @Nullable final String errorMessage) {
+        if (ref == null) {
+            final String nonNullErrorMessage = String.valueOf(errorMessage); // if null, the string will be "null"
+            throw new NullPointerException(nonNullErrorMessage);
+        }
+        return ref;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -174,12 +174,6 @@
 
             <!-- Libraries that make working in java easier -->
             <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${version.guava}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.jetbrains</groupId>
                 <artifactId>annotations</artifactId>
                 <version>${version.jetbrains.annotations}</version>
@@ -221,6 +215,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${version.guava}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${version.assertj-core}</version>
@@ -239,11 +239,6 @@
 
         <!-- Libraries that make working in java easier -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
         </dependency>
@@ -256,6 +251,10 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>


### PR DESCRIPTION
All modules have been updated to no longer depend on Guava functionality
for main code.

Sleepy framework still depends on Guava at compile scope, but it is not
a library others will depend on.