### PR TITLE
Added getter for Mesos-Stream-Id

### DIFF
--- a/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/MesosClient.java
+++ b/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/MesosClient.java
@@ -420,4 +420,9 @@ public final class MesosClient<Send, Receive> {
             );
         };
     }
+
+    @NotNull
+    public String getMesosStreamId() {
+        return mesosStreamId.get();
+    }
 }


### PR DESCRIPTION
We are using Mesos Rx Java and want to perform a kill call. Since we are not sure how a kill should be done with the Rx client we decided to use a normal REST call. However, from reading the docs on the Scheduler HTTP API it seems I require the `Mesos-Stream-Id` that is private in the `MesosClient`. This PR creates a getter for it. This is quite hacky of course so let me know what's the proper way to do this. 




