### PR TITLE
Update SinkSubscriber behavior and thread usage

### DIFF
--- a/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/ResponseUtils.java
+++ b/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/ResponseUtils.java
@@ -1,0 +1,63 @@
+/*
+ *    Copyright (C) 2017 Mesosphere, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mesosphere.mesos.rx.java;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.reactivex.netty.protocol.http.client.HttpClientResponse;
+import io.reactivex.netty.protocol.http.client.HttpResponseHeaders;
+import org.jetbrains.annotations.NotNull;
+import rx.Observable;
+
+import java.nio.charset.StandardCharsets;
+
+final class ResponseUtils {
+
+    private ResponseUtils() {}
+
+    @NotNull
+    static Observable<String> attemptToReadErrorResponse(@NotNull final HttpClientResponse<ByteBuf> resp) {
+        return attemptToReadErrorResponse(resp, true);
+    }
+
+    @NotNull
+    static Observable<String> attemptToReadErrorResponse(@NotNull final HttpClientResponse<ByteBuf> resp, final boolean ignoreContentWhenUnreadable) {
+        final HttpResponseHeaders headers = resp.getHeaders();
+        final String contentType = resp.getHeaders().get(HttpHeaderNames.CONTENT_TYPE);
+        if (headers.isContentLengthSet() && headers.getContentLength() > 0 ) {
+            if (contentType != null && contentType.startsWith("text/plain")) {
+                return resp.getContent()
+                    .map(r -> r.toString(StandardCharsets.UTF_8));
+            } else {
+                if (ignoreContentWhenUnreadable) {
+                    resp.ignoreContent();
+                }
+                final String errMsg = getErrMsg(contentType);
+                return Observable.just(errMsg);
+            }
+        } else {
+            return Observable.just("");
+        }
+    }
+
+    private static String getErrMsg(final String contentType) {
+        if (contentType == null) {
+            return "Not attempting to decode error response with unspecified Content-Type";
+        }
+        return String.format("Not attempting to decode error response of type '%s' as string", contentType);
+    }
+}

--- a/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/SinkSubscriber.java
+++ b/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/SinkSubscriber.java
@@ -55,7 +55,7 @@ final class SinkSubscriber<Send> extends Subscriber<SinkOperation<Send>> {
             final Send toSink = op.getThingToSink();
             createPost.call(toSink)
                 .flatMap(httpClient::submit)
-                .subscribeOn(Rx.compute())
+                .observeOn(Rx.compute())
                 .subscribe(resp -> {
                     final HttpResponseStatus status = resp.getStatus();
                     final int code = status.code();

--- a/mesos-rxjava-client/src/test/java/com/mesosphere/mesos/rx/java/ResponseUtilsTest.java
+++ b/mesos-rxjava-client/src/test/java/com/mesosphere/mesos/rx/java/ResponseUtilsTest.java
@@ -1,0 +1,149 @@
+/*
+ *    Copyright (C) 2017 Mesosphere, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mesosphere.mesos.rx.java;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.reactivex.netty.protocol.http.UnicastContentSubject;
+import io.reactivex.netty.protocol.http.client.HttpClientResponse;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import rx.functions.Action1;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ResponseUtilsTest {
+    
+    @Test
+    public void attemptToReadErrorResponse_plainString() throws Exception {
+        final String errMsg = "some response";
+        final byte[] bytes = errMsg.getBytes(StandardCharsets.UTF_8);
+        final HttpClientResponse<ByteBuf> resp = response(Unpooled.copiedBuffer(bytes), (headers) -> {
+            headers.add("Content-Type", "text/plain;charset=utf-8");
+            headers.add("Content-Length", bytes.length);
+        });
+
+        final String err = ResponseUtils.attemptToReadErrorResponse(resp).toBlocking().first();
+        assertThat(err).isEqualTo(errMsg);
+    }
+
+    @Test
+    public void attemptToReadErrorResponse_noContentLength() throws Exception {
+        final String errMsg = "some response";
+        final byte[] bytes = errMsg.getBytes(StandardCharsets.UTF_8);
+        final HttpClientResponse<ByteBuf> resp = response(Unpooled.copiedBuffer(bytes), (headers) ->
+            headers.add("Content-Type", "text/plain;charset=utf-8")
+        );
+
+        final String err = ResponseUtils.attemptToReadErrorResponse(resp).toBlocking().first();
+        assertThat(err).isEqualTo("");
+    }
+
+    @Test
+    public void attemptToReadErrorResponse_noContentType() throws Exception {
+        final String errMsg = "some response";
+        final byte[] bytes = errMsg.getBytes(StandardCharsets.UTF_8);
+        final HttpClientResponse<ByteBuf> resp = response(Unpooled.copiedBuffer(bytes), (headers) ->
+            headers.add("Content-Length", bytes.length)
+        );
+
+        final String err = ResponseUtils.attemptToReadErrorResponse(resp).toBlocking().first();
+        assertThat(err).isEqualTo("Not attempting to decode error response with unspecified Content-Type");
+    }
+
+    @Test
+    public void attemptToReadErrorResponse_contentLengthIsZero() throws Exception {
+        final HttpClientResponse<ByteBuf> resp = response(Unpooled.copiedBuffer(new byte[]{}), (headers) ->
+            headers.add("Content-Length", "0")
+        );
+
+        final String err = ResponseUtils.attemptToReadErrorResponse(resp).toBlocking().first();
+        assertThat(err).isEqualTo("");
+    }
+
+    @Test
+    public void attemptToReadErrorResponse_nonTextPlain() throws Exception {
+        final String errMsg = "{\"some\":\"json\"}";
+        final byte[] bytes = errMsg.getBytes(StandardCharsets.UTF_8);
+        final HttpClientResponse<ByteBuf> resp = response(Unpooled.copiedBuffer(bytes), (headers) -> {
+            headers.add("Content-Type", "application/json;charset=utf-8");
+            headers.add("Content-Length", bytes.length);
+        });
+
+        final String err = ResponseUtils.attemptToReadErrorResponse(resp).toBlocking().first();
+        assertThat(err).isEqualTo("Not attempting to decode error response of type 'application/json;charset=utf-8' as string");
+    }
+
+    @Test
+    public void attemptToReadErrorResponse_responseContentIgnoredByDefaultWhenNotString() throws Exception {
+        final String errMsg = "lies";
+        final byte[] bytes = errMsg.getBytes(StandardCharsets.UTF_8);
+        final HttpClientResponse<ByteBuf> resp = response(Unpooled.copiedBuffer(bytes), (headers) -> {
+            headers.add("Content-Type", "application/json;charset=utf-8");
+            headers.add("Content-Length", bytes.length);
+        });
+
+        final String err = ResponseUtils.attemptToReadErrorResponse(resp).toBlocking().first();
+        assertThat(err).isNotEqualTo("lies");
+
+        try {
+            resp.getContent().toBlocking().first();
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage()).isEqualTo("Content stream is already disposed.");
+        }
+    }
+
+    @Test
+    public void attemptToReadErrorResponse_responseContentNotIgnoredWhenFalse() throws Exception {
+        final String errMsg = "lies";
+        final byte[] bytes = errMsg.getBytes(StandardCharsets.UTF_8);
+        final HttpClientResponse<ByteBuf> resp = response(Unpooled.copiedBuffer(bytes), (headers) -> {
+            headers.add("Content-Type", "application/json;charset=utf-8");
+            headers.add("Content-Length", bytes.length);
+        });
+
+        final String err = ResponseUtils.attemptToReadErrorResponse(resp, false).toBlocking().first();
+        assertThat(err).isNotEqualTo("lies");
+
+        final String first = resp.getContent()
+            .map(buf -> buf.toString(StandardCharsets.UTF_8))
+            .toBlocking().first();
+        assertThat(first).isEqualTo("lies");
+    }
+
+    private static HttpClientResponse<ByteBuf> response(
+        @NotNull final ByteBuf content,
+        @NotNull final Action1<HttpHeaders> headerTransformer
+    ) {
+        final DefaultHttpResponse nettyResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        headerTransformer.call(nettyResponse.headers());
+        final UnicastContentSubject<ByteBuf> subject = UnicastContentSubject.create(1000, TimeUnit.MILLISECONDS);
+        subject.onNext(content);
+        return new HttpClientResponse<>(
+            nettyResponse,
+            subject
+        );
+    }
+
+}


### PR DESCRIPTION
* Update SinkSubscriber to process callbacks on compute thread
* Update non 202 response handling of SinkSubscriber so that it follows
  the same pattern MesosClient uses when subscribe calls. Primarily
  regarding how the response body is handled. (If the response is
  'text/plain' the body will be read as a UTF-8 string and set as the
  message property of the MesosClientErrorContext in the exception).

Fixes #58 