### PR TITLE
Ensure all background threads are daemon threads

### DIFF
--- a/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/MesosClient.java
+++ b/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/MesosClient.java
@@ -23,6 +23,7 @@ import com.mesosphere.mesos.rx.java.util.UserAgentEntry;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.protocol.http.client.*;
 import org.jetbrains.annotations.NotNull;
@@ -62,7 +63,9 @@ public final class MesosClient<Send, Receive> {
     private static final String MESOS_STREAM_ID = "Mesos-Stream-Id";
 
     @NotNull
-    private final ExecutorService exec = Executors.newSingleThreadExecutor(r -> new Thread(r, "stream-monitor-thread"));
+    private final ExecutorService exec = Executors.newSingleThreadExecutor(
+        new DefaultThreadFactory("stream-monitor-thread", true)
+    );
 
     @NotNull
     private final URI mesosUri;

--- a/mesos-rxjava-test/src/main/java/com/mesosphere/mesos/rx/java/test/Async.java
+++ b/mesos-rxjava-test/src/main/java/com/mesosphere/mesos/rx/java/test/Async.java
@@ -66,7 +66,7 @@ public final class Async extends Verifier {
 
     public Async() {
         counter = new AtomicInteger(0);
-        executor = Executors.newCachedThreadPool(new DefaultThreadFactory(Async.class));
+        executor = Executors.newCachedThreadPool(new DefaultThreadFactory(Async.class, true));
         tasks = Collections.synchronizedList(new ArrayList<>());
     }
 

--- a/mesos-rxjava-test/src/main/java/com/mesosphere/mesos/rx/java/test/TcpSocketProxy.java
+++ b/mesos-rxjava-test/src/main/java/com/mesosphere/mesos/rx/java/test/TcpSocketProxy.java
@@ -16,6 +16,7 @@
 
 package com.mesosphere.mesos.rx.java.test;
 
+import io.netty.util.concurrent.DefaultThreadFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -34,7 +35,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -45,15 +45,13 @@ public final class TcpSocketProxy implements Closeable {
     private static final Logger LOGGER = LoggerFactory.getLogger(TcpSocketProxy.class);
 
     @NotNull
-    private final AtomicInteger threadCounter = new AtomicInteger(1);
-    @NotNull
     private final ExecutorService service = Executors.newCachedThreadPool(
-        r -> new Thread(r, "TcpSocketProxy-" + threadCounter.getAndIncrement())
+        new DefaultThreadFactory("TcpSocketProxy", true)
     );
 
     @NotNull
     private final ScheduledExecutorService murderService = Executors.newSingleThreadScheduledExecutor(
-        r -> new Thread(r, "TcpSocketProxy-murderer")
+        new DefaultThreadFactory("TcpSocketProxy-murderer", true)
     );
 
     @NotNull


### PR DESCRIPTION
Ensure all background threads are daemon threads so that it is not
possible to block the main process from exiting.