### PR TITLE
Retain auth information after redirects

### DIFF
--- a/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/MesosClient.java
+++ b/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/MesosClient.java
@@ -209,7 +209,7 @@ public final class MesosClient<Send, Receive> {
         try {
             return new URI(
                 relativeUri.getScheme(),
-                relativeUri.getUserInfo(),
+                mesosUri.getUserInfo(),
                 relativeUri.getHost(),
                 relativeUri.getPort(),
                 mesosUri.getPath(),

--- a/mesos-rxjava-client/src/test/java/com/mesosphere/mesos/rx/java/MesosClientTest.java
+++ b/mesos-rxjava-client/src/test/java/com/mesosphere/mesos/rx/java/MesosClientTest.java
@@ -284,7 +284,7 @@ public final class MesosClientTest {
 
     @Test
     public void testGetUriFromRedirectResponse() throws Exception {
-        final URI mesosUri = URI.create("http://127.1.0.1:5050/api/v1/scheduler");
+        final URI mesosUri = URI.create("http://username:password@127.1.0.1:5050/api/v1/scheduler");
         final DefaultHttpResponse nettyResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.TEMPORARY_REDIRECT);
         nettyResponse.headers().add("Location", "//127.1.0.2:5050");
         final HttpClientResponse<ByteBuf> response = new HttpClientResponse<>(
@@ -292,7 +292,7 @@ public final class MesosClientTest {
             UnicastContentSubject.create(1000, TimeUnit.MILLISECONDS)
         );
         final URI uri = MesosClient.getUriFromRedirectResponse(mesosUri, response);
-        assertThat(uri).isEqualTo(URI.create("http://127.1.0.2:5050/api/v1/scheduler"));
+        assertThat(uri).isEqualTo(URI.create("http://username:password@127.1.0.2:5050/api/v1/scheduler"));
     }
 
     @Test


### PR DESCRIPTION
Some users of our Singularity mesos framework have noticed that, when passed a user:password to connect to mesos as part of the master uri, that auth info is not retained when redirected to a new master. This PR updates the client to retain the original auth info provided when the original master we connect to is not the leader and we get redirected.

I've updated this in one test, which I verified failed before the change in MesosClient and passed afterwards. Happy to add user:password to more of the URI tests if you believe it is useful.