### PR TITLE
Add ability to run with DC/OS Enterprise strict security mode

### DIFF
--- a/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/MesosClientBuilder.java
+++ b/mesos-rxjava-client/src/main/java/com/mesosphere/mesos/rx/java/MesosClientBuilder.java
@@ -25,8 +25,10 @@ import rx.Observable;
 import rx.functions.Action0;
 
 import java.net.URI;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static com.mesosphere.mesos.rx.java.util.Validations.checkNotNull;
 
@@ -46,6 +48,7 @@ public final class MesosClientBuilder<Send, Receive> {
     private Send subscribe;
     private Function<Observable<Receive>, Observable<Optional<SinkOperation<Send>>>> streamProcessor;
     private Observable.Transformer<byte[], byte[]> backpressureTransformer;
+    private Supplier<Map<String, String>> headerSupplier;
 
     private MesosClientBuilder() {
         backpressureTransformer = observable -> observable;
@@ -208,6 +211,21 @@ public final class MesosClientBuilder<Send, Receive> {
         return this;
     }
 
+
+    /**
+     * Provides a supplier that will be called to supply arbitrary HTTP headers.
+     *
+     * @param headerSupplier supplier callback for arbitrary HTTP request headers
+     * @return this builder (allowing for further chained calls)
+     */
+    @NotNull
+    public MesosClientBuilder<Send, Receive> headerSupplier(
+            @NotNull final Supplier<Map<String, String>> headerSupplier
+            ) {
+        this.headerSupplier = headerSupplier;
+        return this;
+    }
+
     /**
      * Instructs the HTTP byte[] stream to be composed with reactive pull backpressure such that
      * a burst of incoming Mesos messages is handled by a bounded buffer rather than a
@@ -259,7 +277,8 @@ public final class MesosClientBuilder<Send, Receive> {
             checkNotNull(receiveCodec),
             checkNotNull(subscribe),
             checkNotNull(streamProcessor),
-            checkNotNull(backpressureTransformer)
+            checkNotNull(backpressureTransformer),
+            headerSupplier
         );
     }
 

--- a/mesos-rxjava-client/src/test/java/com/mesosphere/mesos/rx/java/MesosClientTest.java
+++ b/mesos-rxjava-client/src/test/java/com/mesosphere/mesos/rx/java/MesosClientTest.java
@@ -76,8 +76,8 @@ public final class MesosClientTest {
             new UserAgent(
                 literal("testing", "latest")
             ),
-            new AtomicReference<>(null)
-        );
+            new AtomicReference<>(null),
+                null);
 
         final HttpClientRequest<ByteBuf> request = createPost.call("something")
             .toBlocking()
@@ -95,8 +95,8 @@ public final class MesosClientTest {
             new UserAgent(
                 literal("testing", "latest")
             ),
-            new AtomicReference<>(null)
-        );
+            new AtomicReference<>(null),
+                null);
 
         final HttpClientRequest<ByteBuf> request = createPost.call("something")
             .toBlocking()
@@ -122,8 +122,8 @@ public final class MesosClientTest {
             new UserAgent(
                 literal("testing", "latest")
             ),
-            new AtomicReference<>("streamId")
-        );
+            new AtomicReference<>("streamId"),
+                null);
 
         final HttpClientRequest<ByteBuf> request = createPost.call("something")
             .toBlocking()
@@ -143,8 +143,8 @@ public final class MesosClientTest {
             new UserAgent(
                 literal("testing", "latest")
             ),
-            new AtomicReference<>(null)
-        );
+            new AtomicReference<>(null),
+                null);
 
         final HttpClientRequest<ByteBuf> request = createPost.call("something")
             .toBlocking()


### PR DESCRIPTION
### DC/OS Enterprise Support

This is in support of #86 

On DC/OS Enterprise, one can run with a strict security mode. In this environment, DC/OS schedulers cannot talk directly to Mesos masters on port 5050, but must rather go through DC/OS adminrouter. This requires 2 things not previously present in mesos-rxjava

1. HTTPS support (talking to adminrouter over https)
2. Ability to set an Authorization header 

I did not do anything additionally to support enterprise other than the 2 items above. I took care of actually authenticating a service account and refreshing the token within my scheduler.

**NOTE:** I am aware that I need to add some tests and comments to make this PR complete. I wanted to at least get this out there for initial review as I know the project has changed ownership. I can follow any new guidance on formatting, docs, tests, etc.

Thanks!